### PR TITLE
Add sum to min_max component

### DIFF
--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     CONF_TYPE,
     ATTR_UNIT_OF_MEASUREMENT,
-    
 )
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     CONF_TYPE,
     ATTR_UNIT_OF_MEASUREMENT,
+    
 )
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
@@ -23,6 +24,7 @@ ATTR_MAX_VALUE = "max_value"
 ATTR_COUNT_SENSORS = "count_sensors"
 ATTR_MEAN = "mean"
 ATTR_LAST = "last"
+ATTR_SUM = "sum"
 
 ATTR_TO_PROPERTY = [
     ATTR_COUNT_SENSORS,
@@ -30,6 +32,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEAN,
     ATTR_MIN_VALUE,
     ATTR_LAST,
+    ATTR_SUM,
 ]
 
 CONF_ENTITY_IDS = "entity_ids"
@@ -42,6 +45,7 @@ SENSOR_TYPES = {
     ATTR_MAX_VALUE: "max",
     ATTR_MEAN: "mean",
     ATTR_LAST: "last",
+    ATTR_SUM: "sum",
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -102,6 +106,15 @@ def calc_mean(sensor_values, round_digits):
     return round(val / count, round_digits)
 
 
+def calc_sum(sensor_values, round_digits):                                                                                 
+    """Calculate max value, honoring unknown states."""                                                                    
+    val = 0                                                                                                                
+    for sval in sensor_values:                                                                                             
+        if sval != STATE_UNKNOWN:                                                                                          
+            val += sval                                                                                                    
+    return round(val, round_digits)      
+
+
 class MinMaxSensor(Entity):
     """Representation of a min/max sensor."""
 
@@ -120,7 +133,7 @@ class MinMaxSensor(Entity):
             ).capitalize()
         self._unit_of_measurement = None
         self._unit_of_measurement_mismatch = False
-        self.min_value = self.max_value = self.mean = self.last = None
+        self.min_value = self.max_value = self.mean = self.last = self.sum = None
         self.count_sensors = len(self._entity_ids)
         self.states = {}
 
@@ -207,3 +220,4 @@ class MinMaxSensor(Entity):
         self.min_value = calc_min(sensor_values)
         self.max_value = calc_max(sensor_values)
         self.mean = calc_mean(sensor_values, self._round_digits)
+        self.sum = calc_sum(sensor_values, self._round_digits) 


### PR DESCRIPTION
## Description:
Add the possibility to sum sensors in min_max component. (for example to have the sum of kWh)

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml`
```yaml
sensor:                                                                                                                                                                                                       
  - platform: min_max                                                                                                                                                                                         
    name: kWhTot                                                                                                                                                                                              
    type: sum                                                                                                                                                                                                 
    entity_ids:                                                                                                                                                                                               
      - sensor.frigo_aujourd_hui                                                                                                                                                                              
      - sensor.frigocave_aujourd_hui                                                                                                                                                                          
      - sensor.chaudiere_aujourd_hui                                                                                                                                                                          
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
